### PR TITLE
fix: make CRON_SECRET required and remove auth header

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -25,7 +25,7 @@ export const env = createEnv({
     // Admin Configuration
     ADMIN_EMAILS: z.string().optional().default(''),
     // Cron Security
-    CRON_SECRET: z.string().optional(),
+    CRON_SECRET: z.string(),
   },
 
   /**

--- a/vercel.json
+++ b/vercel.json
@@ -8,10 +8,7 @@
   "crons": [
     {
       "path": "/api/cron/monthly-credits",
-      "schedule": "0 2 1 * *",
-      "headers": {
-        "Authorization": "Bearer $CRON_SECRET"
-      }
+      "schedule": "0 2 1 * *"
     }
   ]
 }


### PR DESCRIPTION
The CRON_SECRET environment variable is now required for security. Removed the authorization header from vercel.json as it's no longer needed with the updated configuration.